### PR TITLE
fixed handling mm/dd/yyyy;

### DIFF
--- a/timesheet.js
+++ b/timesheet.js
@@ -156,7 +156,7 @@ function parse(line, summary) {
     logger.log('info', line);
     if (line[0] == '#')
         return;
-    if (line.match(/^\d+\/\d+$/)) {
+    if (line.lastIndexOf('/')>0) {
         current = line;
         summary[current] = {
             'daytotal': 0


### PR DESCRIPTION
Sloppy, frantic mm/dd/YYYY fix:

supports 4 year date during year crossover:
`tasks="train":"3598","vista":"18010","ss":"16093","title":"16095","citapple":"17786","dartta":"17089","int":"3595","ugta":"17716","sales":"3597","citmc":"17232","ship":"6952","citta":"16487","tt":"14377","fj":"16097","acushnbt":"16693","citnbt":"16703","ttnbt":"17394","headwear":"17518","techleader":"6952","sick":"5","floating":"6","vac":"3","hol":"22", "korea":"18276"

12/30/2019
train,all day sfmc training practice exam,480

12/31/2019
sick,sick,480

1/1
hol,holiday,480

1/2
train,sfmc training,480

1/3
ss,scrum,30
dart,review kount estimate,30
title, AUG-282 review and dicussions,30
int,joe - pankaj 1 on 1,30
train,sfmc consultant training,360
`